### PR TITLE
set up for hosting from cloud instance

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,9 +52,8 @@ fastify.route({
   handler: async (request, reply) => {
     try {
       const dicomDB = fastify.couch.db.use('chronicle');
-      const body = await dicomDB.get(request.params.instance)
       reply.header('Content-Disposition', `attachment; filename=${request.params.instance}.dcm`);      
-      reply.send(fs.createReadStream(body.fileNamePath))
+      reply.send(dicomDB.attachment.getAsStream(request.params.instance, "object.dcm"))
     }
     catch(err) {
       reply.send(err);

--- a/server.js
+++ b/server.js
@@ -92,7 +92,7 @@ fastify.route({
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(5984, '0.0.0.0')
+    await fastify.listen(5985, '0.0.0.0')
     fastify.log.info(`server listening on ${fastify.server.address().port}`)
   } catch (err) {
     fastify.log.error(err)

--- a/server.js
+++ b/server.js
@@ -92,7 +92,7 @@ fastify.route({
 // Run the server!
 const start = async () => {
   try {
-    await fastify.listen(3000)
+    await fastify.listen(5984, '0.0.0.0')
     fastify.log.info(`server listening on ${fastify.server.address().port}`)
   } catch (err) {
     fastify.log.error(err)


### PR DESCRIPTION
These changes allow us to set up a public testing server.

For example:

```
curl quantome.org:5985/studies/x/series/x/instances/2.25.149307633163361370193039713393133126344 -o /tmp/file.dcm
```